### PR TITLE
Skip integration tests when required env vars are missing

### DIFF
--- a/tests/integration/conversation.integration.test.ts
+++ b/tests/integration/conversation.integration.test.ts
@@ -5,6 +5,17 @@ import { AmigoClient, errors } from '../../src/index'
 // Load environment variables from .env file
 loadEnv()
 
+const requiredEnvVars = ['AMIGO_API_KEY', 'AMIGO_API_KEY_ID', 'AMIGO_USER_ID', 'AMIGO_ORGANIZATION_ID'] as const
+const hasIntegrationEnv = requiredEnvVars.every(name => Boolean(process.env[name]))
+
+if (!hasIntegrationEnv) {
+  console.warn(
+    `Skipping conversation integration tests. Missing one of: ${requiredEnvVars.join(', ')}`
+  )
+}
+
+const integrationSuite = (hasIntegrationEnv ? describe.sequential : describe.skip) as typeof describe
+
 // Real API configuration - these should be valid credentials for testing
 const testConfig = {
   apiKey: process.env.AMIGO_API_KEY || 'test-api-key',
@@ -15,7 +26,7 @@ const testConfig = {
 }
 
 // Use a single conversation across tests to reduce noise
-describe.sequential('Integration - Conversation (Real API)', () => {
+integrationSuite('Integration - Conversation (Real API)', () => {
   const serviceId = '689b81e7afdaf934f4b48f81'
   let client: AmigoClient
   let conversationId: string | undefined

--- a/tests/integration/organization.integration.test.ts
+++ b/tests/integration/organization.integration.test.ts
@@ -5,6 +5,17 @@ import { AmigoClient, errors } from '../../src/index'
 // Load environment variables from .env file
 config()
 
+const requiredEnvVars = ['AMIGO_API_KEY', 'AMIGO_API_KEY_ID', 'AMIGO_USER_ID', 'AMIGO_ORGANIZATION_ID'] as const
+const hasIntegrationEnv = requiredEnvVars.every(name => Boolean(process.env[name]))
+
+if (!hasIntegrationEnv) {
+  console.warn(
+    `Skipping organization integration tests. Missing one of: ${requiredEnvVars.join(', ')}`
+  )
+}
+
+const integrationSuite = (hasIntegrationEnv ? describe : describe.skip) as typeof describe
+
 /**
  * Integration tests for AmigoClient against real API endpoints.
  * These tests are skipped by default and should only be run manually during demos.
@@ -19,7 +30,7 @@ const testConfig = {
   baseUrl: process.env.AMIGO_BASE_URL || 'https://internal-api.amigo.ai',
 }
 
-describe('Integration Tests - Real API', () => {
+integrationSuite('Integration Tests - Real API', () => {
   let client: AmigoClient
 
   test('should get organization data successfully', async () => {

--- a/tests/integration/user.integration.test.ts
+++ b/tests/integration/user.integration.test.ts
@@ -6,6 +6,15 @@ import type { components } from '../../src/generated/api-types'
 // Load environment variables from .env file
 loadEnv()
 
+const requiredEnvVars = ['AMIGO_API_KEY', 'AMIGO_API_KEY_ID', 'AMIGO_USER_ID', 'AMIGO_ORGANIZATION_ID'] as const
+const hasIntegrationEnv = requiredEnvVars.every(name => Boolean(process.env[name]))
+
+if (!hasIntegrationEnv) {
+  console.warn(`Skipping user integration tests. Missing one of: ${requiredEnvVars.join(', ')}`)
+}
+
+const integrationSuite = (hasIntegrationEnv ? describe.sequential : describe.skip) as typeof describe
+
 // Real API configuration - these should be valid credentials for testing
 const testConfig = {
   apiKey: process.env.AMIGO_API_KEY || 'test-api-key',
@@ -19,7 +28,7 @@ function createClient(config = testConfig) {
   return new AmigoClient(config)
 }
 
-describe.sequential('Integration - User (Real API)', () => {
+integrationSuite('Integration - User (Real API)', () => {
   let createdUserId: string | undefined
   let createdUserEmail: string | undefined
 


### PR DESCRIPTION
## Summary
- Skips integration tests when required environment variables are not set to avoid false failures in CI or local environments lacking Amigo integration credentials.
- Applies a consistent integration suite wrapper across conversation, organization, and user tests.

## Changes
- tests/integration/conversation.integration.test.ts
  - Added requiredEnvVars check and hasIntegrationEnv flag.
  - Warns when env vars are missing and switches to a skipped suite using integrationSuite.
  - Replaced describe.sequential usage with integrationSuite to conditionally run or skip.
- tests/integration/organization.integration.test.ts
  - Added requiredEnvVars check and hasIntegrationEnv flag.
  - Introduced integrationSuite (describe or describe.skip) and used it to wrap tests.
- tests/integration/user.integration.test.ts
  - Added requiredEnvVars check and hasIntegrationEnv flag.
  - Introduced integrationSuite (describe.sequential or describe.skip) and used it to wrap tests.

## Why
- Prevents flaky/failing tests in environments without valid Amigo integration credentials.
- Provides a clear and consistent pattern for gating integration tests behind required environment variables.

## Test plan
- With all required env vars set (AMIGO_API_KEY, AMIGO_API_KEY_ID, AMIGO_USER_ID, AMIGO_ORGANIZATION_ID): run integration tests and verify they execute normally against the real API.
- Without the required env vars: run integration tests and verify they are skipped with a warning indicating the missing variables.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e1fbd3f4-6301-4cc1-bcd8-403969df56bd