### PR TITLE
fix: resolve CI failures and add tests for new resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,15 +31,18 @@ src/
     retry.ts            — Exponential backoff with jitter, Retry-After header support
     openapi-client.ts   — Creates openapi-fetch Client with auth + error + retry middleware
     utils.ts            — NDJSON stream parser, response helpers
+    branded-types.ts    — Branded type aliases and constructor functions (OrgId, UserId, ServiceId, AgentId, etc.)
     rate-limit.ts       — RateLimitInfo type, header parsing, callback type
   webhooks/
     types.ts            — Typed interfaces for webhook events (discriminated union)
     parse.ts            — parseWebhookEvent() with HMAC-SHA256 signature verification
     index.ts            — Re-exports
   resources/
+    agent.ts            — Agent CRUD and versioning (createAgent, getAgents, deleteAgent, createAgentVersion, getAgentVersions)
+    context-graph.ts    — Context graph (HSM) CRUD and versioning (createContextGraph, getContextGraphs, deleteContextGraph, createContextGraphVersion, getContextGraphVersions)
     conversation.ts     — Conversations, interactions, NDJSON streaming, message retrieval
     organization.ts     — Organization management
-    services.ts         — Service configuration
+    services.ts         — Service CRUD, version set management (getServices, createService, updateService, upsertVersionSet, deleteVersionSet)
     user.ts             — User operations
   generated/
     api-types.ts        — Auto-generated OpenAPI types (DO NOT EDIT — run `npm run gen-types`)

--- a/tests/integration/conversation.integration.test.ts
+++ b/tests/integration/conversation.integration.test.ts
@@ -1,7 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeAll } from 'vitest'
 import { config as loadEnv } from 'dotenv'
-import { AmigoClient, ConflictError, NotFoundError } from '../../src/index'
+import {
+  AmigoClient,
+  ConflictError,
+  NotFoundError,
+  userId,
+  orgId,
+  conversationId as toConversationId,
+  interactionId as toInteractionId,
+} from '../../src/index'
+import type { ConversationId, InteractionId } from '../../src/core/branded-types'
 
 // Load environment variables from .env file
 loadEnv()
@@ -10,8 +19,8 @@ loadEnv()
 const testConfig = {
   apiKey: process.env.AMIGO_API_KEY || 'test-api-key',
   apiKeyId: process.env.AMIGO_API_KEY_ID || 'test-api-key-id',
-  userId: process.env.AMIGO_USER_ID || 'test-user-id',
-  orgId: process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id',
+  userId: userId(process.env.AMIGO_USER_ID || 'test-user-id'),
+  orgId: orgId(process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id'),
   baseUrl: process.env.AMIGO_BASE_URL || 'https://internal-api.amigo.ai',
   serviceId: process.env.AMIGO_TEST_SERVICE_ID || '6960124e9b05e7710da71baf',
 }
@@ -20,8 +29,8 @@ const testConfig = {
 describe.sequential('Integration - Conversation (Real API)', () => {
   const serviceId = testConfig.serviceId
   let client: AmigoClient
-  let conversationId: string | undefined
-  let interactionId: string | undefined
+  let conversationId: ConversationId | undefined
+  let interactionId: InteractionId | undefined
 
   // Ensure no unfinished conversations exist for this service before starting
   beforeAll(async () => {
@@ -44,7 +53,7 @@ describe.sequential('Integration - Conversation (Real API)', () => {
       })
       for (const c of existing.conversations ?? []) {
         try {
-          await client.conversations.finishConversation({ conversationId: c.id })
+          await client.conversations.finishConversation({ conversationId: toConversationId(c.id) })
         } catch {
           // Ignore best-effort failures (already finished or conflicts)
         }
@@ -76,13 +85,13 @@ describe.sequential('Integration - Conversation (Real API)', () => {
           throw new Error(`error event: ${JSON.stringify(evt)}`)
         }
         if (type === 'conversation-created') {
-          conversationId = (evt as any).conversation_id
+          conversationId = toConversationId((evt as any).conversation_id)
           expect(typeof conversationId).toBe('string')
         } else if (type === 'new-message') {
           sawNewMessage = true
           expect(typeof (evt as any).message).toBe('string')
         } else if (type === 'interaction-complete') {
-          interactionId = (evt as any).interaction_id
+          interactionId = toInteractionId((evt as any).interaction_id)
           expect(typeof interactionId).toBe('string')
           // We have what we need; stop reading the stream to avoid hanging
           break
@@ -131,7 +140,7 @@ describe.sequential('Integration - Conversation (Real API)', () => {
 
     let sawNewMessage = false
     let sawInteractionComplete = false
-    let latestInteractionId: string | undefined
+    let latestInteractionId: InteractionId | undefined
 
     for await (const evt of events) {
       if (evt && typeof evt === 'object' && 'type' in evt) {
@@ -140,7 +149,7 @@ describe.sequential('Integration - Conversation (Real API)', () => {
           sawNewMessage = true
         } else if (type === 'interaction-complete') {
           sawInteractionComplete = true
-          latestInteractionId = (evt as any).interaction_id
+          latestInteractionId = toInteractionId((evt as any).interaction_id)
           // Stop after completion to avoid waiting for server to close stream
           break
         }

--- a/tests/integration/organization.integration.test.ts
+++ b/tests/integration/organization.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { config } from 'dotenv'
-import { AmigoClient, NotFoundError, AuthenticationError } from '../../src/index'
+import { AmigoClient, NotFoundError, AuthenticationError, userId, orgId } from '../../src/index'
 
 // Load environment variables from .env file
 config()
@@ -14,8 +14,8 @@ config()
 const testConfig = {
   apiKey: process.env.AMIGO_API_KEY || 'test-api-key',
   apiKeyId: process.env.AMIGO_API_KEY_ID || 'test-api-key-id',
-  userId: process.env.AMIGO_USER_ID || 'test-user-id',
-  orgId: process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id',
+  userId: userId(process.env.AMIGO_USER_ID || 'test-user-id'),
+  orgId: orgId(process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id'),
   baseUrl: process.env.AMIGO_BASE_URL || 'https://internal-api.amigo.ai',
 }
 
@@ -41,7 +41,7 @@ describe('Integration Tests - Real API', () => {
   test('should throw NotFoundError for invalid organization ID', async () => {
     const invalidConfig = {
       ...testConfig,
-      orgId: 'invalid-org-id-123',
+      orgId: orgId('invalid-org-id-123'),
     }
     client = new AmigoClient(invalidConfig)
 

--- a/tests/integration/user.integration.test.ts
+++ b/tests/integration/user.integration.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect } from 'vitest'
 import { config as loadEnv } from 'dotenv'
-import { AmigoClient, NotFoundError } from '../../src/index'
+import { AmigoClient, NotFoundError, userId, orgId } from '../../src/index'
+import type { UserId } from '../../src/core/branded-types'
 import type { components } from '../../src/generated/api-types'
 
 // Load environment variables from .env file
@@ -11,8 +12,8 @@ loadEnv()
 const testConfig = {
   apiKey: process.env.AMIGO_API_KEY || 'test-api-key',
   apiKeyId: process.env.AMIGO_API_KEY_ID || 'test-api-key-id',
-  userId: process.env.AMIGO_USER_ID || 'test-user-id',
-  orgId: process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id',
+  userId: userId(process.env.AMIGO_USER_ID || 'test-user-id'),
+  orgId: orgId(process.env.AMIGO_ORGANIZATION_ID || 'valid-org-id'),
   baseUrl: process.env.AMIGO_BASE_URL || 'https://internal-api.amigo.ai',
 }
 
@@ -21,7 +22,7 @@ function createClient(config = testConfig) {
 }
 
 describe.sequential('Integration - User (Real API)', () => {
-  let createdUserId: string | undefined
+  let createdUserId: UserId | undefined
   let createdUserEmail: string | undefined
 
   test('create a test user succeeds and returns created user details', async () => {
@@ -38,7 +39,7 @@ describe.sequential('Integration - User (Real API)', () => {
     const result = await client.users.createUser(body)
     expect(result).toBeDefined()
     expect(typeof result.user_id).toBe('string')
-    createdUserId = result.user_id
+    createdUserId = userId(result.user_id)
     createdUserEmail = email
   })
 
@@ -116,18 +117,18 @@ describe.sequential('Integration - User (Real API)', () => {
       preferred_language: null,
       timezone: null,
     }
-    await expect(client.users.updateUser({ userId: 'non-existent-id', body })).rejects.toThrow(
-      NotFoundError
-    )
+    await expect(
+      client.users.updateUser({ userId: userId('non-existent-id'), body })
+    ).rejects.toThrow(NotFoundError)
   })
 
   test('get users for invalid org returns NotFoundError', async () => {
-    const invalidClient = createClient({ ...testConfig, orgId: 'invalid-org-id-123' })
+    const invalidClient = createClient({ ...testConfig, orgId: orgId('invalid-org-id-123') })
     await expect(invalidClient.users.getUsers()).rejects.toThrow(NotFoundError)
   })
 
   test('delete non-existent user returns NotFoundError', async () => {
     const client = createClient()
-    await expect(client.users.deleteUser('non-existent-id')).rejects.toThrow(NotFoundError)
+    await expect(client.users.deleteUser(userId('non-existent-id'))).rejects.toThrow(NotFoundError)
   })
 })

--- a/tests/resources/agent.test.ts
+++ b/tests/resources/agent.test.ts
@@ -1,0 +1,345 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { AgentResource } from '../../src/resources/agent'
+import { createAmigoFetch } from '../../src/core/openapi-client'
+import { NotFoundError, ValidationError } from '../../src/core/errors'
+import { mockConfig, withMockAuth } from '../test-helpers'
+import { orgId, agentId } from '../../src/core/branded-types'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'bypass' })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('AgentResource', () => {
+  describe('createAgent', () => {
+    test('creates and returns agent', async () => {
+      const mockResponse = { agent_id: 'agent-1', name: 'Test Agent' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(
+            'https://api.example.com/v1/test-org/organization/agent',
+            async ({ request }) => {
+              const body = (await request.json()) as any
+              expect(body.name).toBe('Test Agent')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.createAgent({
+        body: { name: 'Test Agent' } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('forwards headers', async () => {
+      const mockResponse = { agent_id: 'agent-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/organization/agent', ({ request }) => {
+            expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await resource.createAgent({
+        body: { name: 'Test' } as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+
+    test('throws ValidationError on 422', async () => {
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/organization/agent', () => {
+            return HttpResponse.json(
+              { detail: 'bad' },
+              { status: 422, statusText: 'Unprocessable Entity' }
+            )
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await expect(resource.createAgent({ body: {} as any })).rejects.toThrow(ValidationError)
+    })
+  })
+
+  describe('getAgents', () => {
+    test('returns agents list', async () => {
+      const mockResponse = { agents: [], has_more: false, continuation_token: null }
+
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/test-org/organization/agent', () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.getAgents()
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query parameters', async () => {
+      const mockResponse = { agents: [], has_more: false, continuation_token: null }
+
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/test-org/organization/agent', ({ request }) => {
+            const url = new URL(request.url)
+            expect(url.searchParams.get('limit')).toBe('5')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await resource.getAgents({ query: { limit: 5 } as any })
+    })
+
+    test('throws NotFoundError on 404', async () => {
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/bad-org/organization/agent', () => {
+            return HttpResponse.json(null, { status: 404, statusText: 'Not Found' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('bad-org'))
+      await expect(resource.getAgents()).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('deleteAgent', () => {
+    test('returns void on success', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete('https://api.example.com/v1/test-org/organization/agent/agent-1/', () => {
+            return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await expect(resource.deleteAgent({ agentId: agentId('agent-1') })).resolves.toBeUndefined()
+    })
+
+    test('forwards headers on delete', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(
+            'https://api.example.com/v1/test-org/organization/agent/agent-1/',
+            ({ request }) => {
+              expect(request.headers.get('x-mongo-cluster-name')).toBe('xyz')
+              return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await resource.deleteAgent({
+        agentId: agentId('agent-1'),
+        headers: { 'x-mongo-cluster-name': 'xyz' },
+      })
+    })
+
+    test('throws NotFoundError on 404', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete('https://api.example.com/v1/test-org/organization/agent/missing/', () => {
+            return HttpResponse.json(null, { status: 404, statusText: 'Not Found' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await expect(resource.deleteAgent({ agentId: agentId('missing') })).rejects.toThrow(
+        NotFoundError
+      )
+    })
+  })
+
+  describe('createAgentVersion', () => {
+    test('creates and returns agent version', async () => {
+      const mockResponse = { version: 1, agent_id: 'agent-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(
+            'https://api.example.com/v1/test-org/organization/agent/agent-1/',
+            async ({ request }) => {
+              const body = (await request.json()) as any
+              expect(body.persona).toBe('helpful')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.createAgentVersion({
+        agentId: agentId('agent-1'),
+        body: { persona: 'helpful' } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query parameters for dry run', async () => {
+      const mockResponse = { version: 1 }
+
+      server.use(
+        ...withMockAuth(
+          http.post(
+            'https://api.example.com/v1/test-org/organization/agent/agent-1/',
+            ({ request }) => {
+              const url = new URL(request.url)
+              expect(url.searchParams.get('dry_run')).toBe('true')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await resource.createAgentVersion({
+        agentId: agentId('agent-1'),
+        body: {} as any,
+        query: { dry_run: true } as any,
+      })
+    })
+  })
+
+  describe('getAgentVersions', () => {
+    test('returns versions list', async () => {
+      const mockResponse = { versions: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/test-org/organization/agent/agent-1/version', () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.getAgentVersions({
+        agentId: agentId('agent-1'),
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query and header parameters', async () => {
+      const mockResponse = { versions: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get(
+            'https://api.example.com/v1/test-org/organization/agent/agent-1/version',
+            ({ request }) => {
+              const url = new URL(request.url)
+              expect(url.searchParams.get('limit')).toBe('10')
+              expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await resource.getAgentVersions({
+        agentId: agentId('agent-1'),
+        query: { limit: 10 } as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+  })
+
+  describe('convenience aliases', () => {
+    test('list delegates to getAgents', async () => {
+      const mockResponse = { agents: [], has_more: false, continuation_token: null }
+
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/test-org/organization/agent', () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.list()
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('create delegates to createAgent', async () => {
+      const mockResponse = { agent_id: 'agent-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/organization/agent', () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      const result = await resource.create({ body: { name: 'Test' } as any })
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('delete delegates to deleteAgent', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete('https://api.example.com/v1/test-org/organization/agent/agent-1/', () => {
+            return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new AgentResource(client, orgId('test-org'))
+      await expect(resource.delete({ agentId: agentId('agent-1') })).resolves.toBeUndefined()
+    })
+  })
+})

--- a/tests/resources/context-graph.test.ts
+++ b/tests/resources/context-graph.test.ts
@@ -1,0 +1,342 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { ContextGraphResource } from '../../src/resources/context-graph'
+import { createAmigoFetch } from '../../src/core/openapi-client'
+import { NotFoundError, ValidationError } from '../../src/core/errors'
+import { mockConfig, withMockAuth } from '../test-helpers'
+import { orgId } from '../../src/core/branded-types'
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'bypass' })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const HSM_BASE = 'organization/service_hierarchical_state_machine'
+
+describe('ContextGraphResource', () => {
+  describe('createContextGraph', () => {
+    test('creates and returns context graph', async () => {
+      const mockResponse = { id: 'hsm-1', name: 'Test Graph' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(`https://api.example.com/v1/test-org/${HSM_BASE}`, async ({ request }) => {
+            const body = (await request.json()) as any
+            expect(body.name).toBe('Test Graph')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.createContextGraph({
+        body: { name: 'Test Graph' } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('forwards headers', async () => {
+      const mockResponse = { id: 'hsm-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(`https://api.example.com/v1/test-org/${HSM_BASE}`, ({ request }) => {
+            expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await resource.createContextGraph({
+        body: { name: 'Test' } as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+
+    test('throws ValidationError on 422', async () => {
+      server.use(
+        ...withMockAuth(
+          http.post(`https://api.example.com/v1/test-org/${HSM_BASE}`, () => {
+            return HttpResponse.json(
+              { detail: 'bad' },
+              { status: 422, statusText: 'Unprocessable Entity' }
+            )
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await expect(resource.createContextGraph({ body: {} as any })).rejects.toThrow(
+        ValidationError
+      )
+    })
+  })
+
+  describe('getContextGraphs', () => {
+    test('returns context graphs list', async () => {
+      const mockResponse = { state_machines: [], has_more: false, continuation_token: null }
+
+      server.use(
+        ...withMockAuth(
+          http.get(`https://api.example.com/v1/test-org/${HSM_BASE}`, () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.getContextGraphs()
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query parameters', async () => {
+      const mockResponse = { state_machines: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get(`https://api.example.com/v1/test-org/${HSM_BASE}`, ({ request }) => {
+            const url = new URL(request.url)
+            expect(url.searchParams.get('limit')).toBe('5')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await resource.getContextGraphs({ query: { limit: 5 } as any })
+    })
+
+    test('throws NotFoundError on 404', async () => {
+      server.use(
+        ...withMockAuth(
+          http.get(`https://api.example.com/v1/bad-org/${HSM_BASE}`, () => {
+            return HttpResponse.json(null, { status: 404, statusText: 'Not Found' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('bad-org'))
+      await expect(resource.getContextGraphs()).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('createContextGraphVersion', () => {
+    test('creates and returns version', async () => {
+      const mockResponse = { version: 1, id: 'hsm-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(
+            `https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/`,
+            async ({ request }) => {
+              const body = (await request.json()) as any
+              expect(body.states).toBeDefined()
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.createContextGraphVersion({
+        contextGraphId: 'hsm-1',
+        body: { states: [] } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query parameters for dry run', async () => {
+      const mockResponse = { version: 1 }
+
+      server.use(
+        ...withMockAuth(
+          http.post(`https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/`, ({ request }) => {
+            const url = new URL(request.url)
+            expect(url.searchParams.get('dry_run')).toBe('true')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await resource.createContextGraphVersion({
+        contextGraphId: 'hsm-1',
+        body: {} as any,
+        query: { dry_run: true } as any,
+      })
+    })
+  })
+
+  describe('deleteContextGraph', () => {
+    test('returns void on success', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(`https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/`, () => {
+            return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await expect(
+        resource.deleteContextGraph({ contextGraphId: 'hsm-1' })
+      ).resolves.toBeUndefined()
+    })
+
+    test('forwards headers on delete', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(`https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/`, ({ request }) => {
+            expect(request.headers.get('x-mongo-cluster-name')).toBe('xyz')
+            return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await resource.deleteContextGraph({
+        contextGraphId: 'hsm-1',
+        headers: { 'x-mongo-cluster-name': 'xyz' },
+      })
+    })
+
+    test('throws NotFoundError on 404', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(`https://api.example.com/v1/test-org/${HSM_BASE}/missing/`, () => {
+            return HttpResponse.json(null, { status: 404, statusText: 'Not Found' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await expect(resource.deleteContextGraph({ contextGraphId: 'missing' })).rejects.toThrow(
+        NotFoundError
+      )
+    })
+  })
+
+  describe('getContextGraphVersions', () => {
+    test('returns versions list', async () => {
+      const mockResponse = { versions: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get(`https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/version`, () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.getContextGraphVersions({
+        contextGraphId: 'hsm-1',
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('passes query and header parameters', async () => {
+      const mockResponse = { versions: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get(
+            `https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/version`,
+            ({ request }) => {
+              const url = new URL(request.url)
+              expect(url.searchParams.get('limit')).toBe('10')
+              expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await resource.getContextGraphVersions({
+        contextGraphId: 'hsm-1',
+        query: { limit: 10 } as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+  })
+
+  describe('convenience aliases', () => {
+    test('list delegates to getContextGraphs', async () => {
+      const mockResponse = { state_machines: [], has_more: false }
+
+      server.use(
+        ...withMockAuth(
+          http.get(`https://api.example.com/v1/test-org/${HSM_BASE}`, () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.list()
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('create delegates to createContextGraph', async () => {
+      const mockResponse = { id: 'hsm-1' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(`https://api.example.com/v1/test-org/${HSM_BASE}`, () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      const result = await resource.create({ body: { name: 'Test' } as any })
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('delete delegates to deleteContextGraph', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(`https://api.example.com/v1/test-org/${HSM_BASE}/hsm-1/`, () => {
+            return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ContextGraphResource(client, orgId('test-org'))
+      await expect(resource.delete({ contextGraphId: 'hsm-1' })).resolves.toBeUndefined()
+    })
+  })
+})

--- a/tests/resources/conversation.test.ts
+++ b/tests/resources/conversation.test.ts
@@ -5,7 +5,7 @@ import { setupServer } from 'msw/node'
 import { createAmigoFetch } from '../../src/core/openapi-client'
 import { ConversationResource } from '../../src/resources/conversation'
 import { withMockAuth, mockConfig } from '../test-helpers'
-import { conversationId, interactionId, messageId } from '../../src/core/branded-types'
+import { conversationId, interactionId, messageId, orgId } from '../../src/core/branded-types'
 import { NotFoundError, ConflictError } from '../../src/core/errors'
 import type { components } from '../../src/generated/api-types'
 
@@ -58,7 +58,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const events = await resource.createConversation({
         body: {
@@ -111,7 +111,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const events = await resource.createConversation({
         body: {
@@ -140,7 +140,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const controller = new AbortController()
       controller.abort()
@@ -176,7 +176,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       await expect(
         (async () => {
@@ -222,7 +222,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const events = await resource.interactWithConversation({
         conversationId: conversationId('conv-hl-text'),
@@ -256,7 +256,7 @@ describe('ConversationResource', () => {
               const url = new URL(request.url)
               expect(url.searchParams.get('request_format')).toBe('voice')
               expect(url.searchParams.get('response_format')).toBe('text')
-              expect(url.searchParams.get('audio_format')).toBe('mp3')
+
               expect(url.searchParams.get('request_audio_config')).toBe('{"type":"mp3"}')
               return new Response(responseStream, {
                 status: 200,
@@ -268,7 +268,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const audioStream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -283,7 +283,6 @@ describe('ConversationResource', () => {
         query: {
           request_format: 'voice',
           response_format: 'text',
-          audio_format: 'mp3',
           request_audio_config: { type: 'mp3' },
         },
       })
@@ -320,7 +319,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const events = await resource.interactWithConversation({
         conversationId: conversationId('conv-1'),
@@ -355,7 +354,7 @@ describe('ConversationResource', () => {
               const url = new URL(request.url)
               expect(url.searchParams.get('request_format')).toBe('voice')
               expect(url.searchParams.get('response_format')).toBe('text')
-              expect(url.searchParams.get('audio_format')).toBe('mp3')
+
               expect(url.searchParams.get('request_audio_config')).toBe('{"type":"mp3"}')
               expect(request.headers.get('x-mongo-cluster-name')).toBe('test-cluster')
               return new Response(responseStream, {
@@ -368,7 +367,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       const audioStream = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -383,10 +382,10 @@ describe('ConversationResource', () => {
         query: {
           request_format: 'voice',
           response_format: 'text',
-          audio_format: 'mp3',
           request_audio_config: { type: 'mp3' },
         },
         headers: {
+          'content-type': 'multipart/form-data',
           'x-mongo-cluster-name': 'test-cluster',
         },
       })
@@ -409,7 +408,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const controller = new AbortController()
       controller.abort()
 
@@ -421,7 +420,6 @@ describe('ConversationResource', () => {
             query: {
               request_format: 'voice',
               response_format: 'text',
-              audio_format: 'mp3',
               request_audio_config: { type: 'mp3' },
             },
             signal: controller.signal,
@@ -446,7 +444,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
 
       await expect(
         (async () => {
@@ -456,7 +454,6 @@ describe('ConversationResource', () => {
             query: {
               request_format: 'voice',
               response_format: 'text',
-              audio_format: 'mp3',
               request_audio_config: { type: 'mp3' },
             },
           })
@@ -487,7 +484,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.getConversations({
         service_id: ['svc-1', 'svc-2'],
         is_finished: false,
@@ -507,7 +504,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(resource.getConversations()).rejects.toThrow(NotFoundError)
     })
   })
@@ -532,7 +529,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.getConversationMessages({
         conversationId: conversationId('conv-3'),
         query: {
@@ -553,7 +550,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.getConversationMessages({ conversationId: conversationId('missing') })
       ).rejects.toThrow(NotFoundError)
@@ -570,7 +567,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.finishConversation({ conversationId: conversationId('conv-4') })
       ).resolves.toBeUndefined()
@@ -588,7 +585,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.finishConversation({ conversationId: conversationId('conv-6') })
       ).rejects.toThrow(ConflictError)
@@ -603,7 +600,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.finishConversation({ conversationId: conversationId('missing') })
       ).rejects.toThrow(NotFoundError)
@@ -622,7 +619,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.recommendResponsesForInteraction({
         conversationId: conversationId('conv-7'),
         interactionId: interactionId('int-1'),
@@ -640,7 +637,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.recommendResponsesForInteraction({
           conversationId: conversationId('conv-7'),
@@ -662,7 +659,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.getInteractionInsights({
         conversationId: conversationId('conv-8'),
         interactionId: interactionId('int-2'),
@@ -680,7 +677,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.getInteractionInsights({
           conversationId: conversationId('conv-8'),
@@ -702,7 +699,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.getMessageSource({
         conversationId: conversationId('conv-9'),
         messageId: messageId('msg-1'),
@@ -720,7 +717,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.getMessageSource({
           conversationId: conversationId('conv-9'),
@@ -757,7 +754,7 @@ describe('ConversationResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       const data = await resource.generateConversationStarters(
         {
           service_id: 'x',
@@ -786,7 +783,7 @@ describe('ConversationResource', () => {
         )
       )
       const client = createAmigoFetch(mockConfig)
-      const resource = new ConversationResource(client, 'test-org')
+      const resource = new ConversationResource(client, orgId('test-org'))
       await expect(
         resource.generateConversationStarters({
           service_id: 'x',

--- a/tests/resources/organization.test.ts
+++ b/tests/resources/organization.test.ts
@@ -6,6 +6,7 @@ import { createAmigoFetch } from '../../src/core/openapi-client'
 import { NotFoundError } from '../../src/core/errors'
 import type { components } from '../../src/generated/api-types'
 import { mockConfig, withMockAuth } from '../test-helpers'
+import { orgId } from '../../src/core/branded-types'
 
 // Mock organization response
 const mockOrganizationResponse: components['schemas']['organization__get_organization__Response'] =
@@ -46,7 +47,7 @@ describe('OrganizationResource', () => {
     )
 
     const client = createAmigoFetch(mockConfig)
-    const organizationResource = new OrganizationResource(client, 'test-org')
+    const organizationResource = new OrganizationResource(client, orgId('test-org'))
     const result = await organizationResource.getOrganization()
 
     expect(result).toBeDefined()
@@ -66,7 +67,7 @@ describe('OrganizationResource', () => {
     )
 
     const client = createAmigoFetch(mockConfig)
-    const organizationResource = new OrganizationResource(client, 'nonexistent-org')
+    const organizationResource = new OrganizationResource(client, orgId('nonexistent-org'))
 
     await expect(organizationResource.getOrganization()).rejects.toThrow(NotFoundError)
   })

--- a/tests/resources/services.test.ts
+++ b/tests/resources/services.test.ts
@@ -1,11 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { ServiceResource } from '../../src/resources/services'
 import { createAmigoFetch } from '../../src/core/openapi-client'
-import { NotFoundError } from '../../src/core/errors'
+import { NotFoundError, ValidationError } from '../../src/core/errors'
 import type { components } from '../../src/generated/api-types'
 import { mockConfig, withMockAuth } from '../test-helpers'
+import { orgId, serviceId } from '../../src/core/branded-types'
 
 // Mock service instance
 const mockService: components['schemas']['ServiceInstance'] = {
@@ -17,6 +19,9 @@ const mockService: components['schemas']['ServiceInstance'] = {
   service_hierarchical_state_machine_id: 'hsm-456',
   agent_id: 'agent-789',
   tags: [],
+  keyterms: [],
+  creator: { org_id: 'test-org', user_id: 'user-1' },
+  updated_by: { org_id: 'test-org', user_id: 'user-1' },
 }
 
 // Mock services response
@@ -54,7 +59,7 @@ describe('ServiceResource', () => {
     )
 
     const client = createAmigoFetch(mockConfig)
-    const serviceResource = new ServiceResource(client, 'test-org')
+    const serviceResource = new ServiceResource(client, orgId('test-org'))
     const result = await serviceResource.getServices()
 
     expect(result).toBeDefined()
@@ -76,8 +81,285 @@ describe('ServiceResource', () => {
     )
 
     const client = createAmigoFetch(mockConfig)
-    const serviceResource = new ServiceResource(client, 'nonexistent-org')
+    const serviceResource = new ServiceResource(client, orgId('nonexistent-org'))
 
     await expect(serviceResource.getServices()).rejects.toThrow(NotFoundError)
+  })
+
+  test('getServices passes query parameters and headers', async () => {
+    server.use(
+      ...withMockAuth(
+        http.get('https://api.example.com/v1/test-org/service/', ({ request }) => {
+          const url = new URL(request.url)
+          expect(url.searchParams.get('limit')).toBe('5')
+          expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+          return HttpResponse.json(mockServicesResponse)
+        })
+      )
+    )
+
+    const client = createAmigoFetch(mockConfig)
+    const resource = new ServiceResource(client, orgId('test-org'))
+    await resource.getServices({ limit: 5 } as any, { 'x-mongo-cluster-name': 'abc' })
+  })
+
+  describe('createService', () => {
+    test('creates and returns service', async () => {
+      const mockResponse = { id: 'service-new', name: 'New Service' }
+
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/service/', async ({ request }) => {
+            const body = (await request.json()) as any
+            expect(body.name).toBe('New Service')
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      const result = await resource.createService({
+        body: { name: 'New Service' } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('forwards headers', async () => {
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/service/', ({ request }) => {
+            expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+            return HttpResponse.json({ id: 'service-new' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await resource.createService({
+        body: { name: 'Test' } as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+
+    test('throws ValidationError on 422', async () => {
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/service/', () => {
+            return HttpResponse.json(
+              { detail: 'bad' },
+              { status: 422, statusText: 'Unprocessable Entity' }
+            )
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await expect(resource.createService({ body: {} as any })).rejects.toThrow(ValidationError)
+    })
+  })
+
+  describe('updateService', () => {
+    test('updates and returns service', async () => {
+      const mockResponse = { id: 'service-123', name: 'Updated' }
+
+      server.use(
+        ...withMockAuth(
+          http.post(
+            'https://api.example.com/v1/test-org/service/service-123/',
+            async ({ request }) => {
+              const body = (await request.json()) as any
+              expect(body.name).toBe('Updated')
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      const result = await resource.updateService({
+        serviceId: serviceId('service-123'),
+        body: { name: 'Updated' } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('forwards headers', async () => {
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/service/service-123/', ({ request }) => {
+            expect(request.headers.get('x-mongo-cluster-name')).toBe('xyz')
+            return HttpResponse.json({ id: 'service-123' })
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await resource.updateService({
+        serviceId: serviceId('service-123'),
+        body: { name: 'Updated' } as any,
+        headers: { 'x-mongo-cluster-name': 'xyz' },
+      })
+    })
+  })
+
+  describe('upsertVersionSet', () => {
+    test('upserts and returns version set', async () => {
+      const mockResponse = { version_set_name: 'release', versions: {} }
+
+      server.use(
+        ...withMockAuth(
+          http.put(
+            'https://api.example.com/v1/test-org/service/service-123/version_sets/release/',
+            async ({ request }) => {
+              const body = (await request.json()) as any
+              expect(body).toBeDefined()
+              return HttpResponse.json(mockResponse)
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      const result = await resource.upsertVersionSet({
+        serviceId: serviceId('service-123'),
+        versionSetName: 'release',
+        body: { agent_version: 1 } as any,
+      })
+
+      expect(result).toEqual(mockResponse as unknown)
+    })
+
+    test('forwards headers', async () => {
+      server.use(
+        ...withMockAuth(
+          http.put(
+            'https://api.example.com/v1/test-org/service/service-123/version_sets/staging/',
+            ({ request }) => {
+              expect(request.headers.get('x-mongo-cluster-name')).toBe('abc')
+              return HttpResponse.json({ version_set_name: 'staging' })
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await resource.upsertVersionSet({
+        serviceId: serviceId('service-123'),
+        versionSetName: 'staging',
+        body: {} as any,
+        headers: { 'x-mongo-cluster-name': 'abc' },
+      })
+    })
+  })
+
+  describe('deleteVersionSet', () => {
+    test('returns void on success', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(
+            'https://api.example.com/v1/test-org/service/service-123/version_sets/dev/',
+            () => {
+              return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await expect(
+        resource.deleteVersionSet({
+          serviceId: serviceId('service-123'),
+          versionSetName: 'dev',
+        })
+      ).resolves.toBeUndefined()
+    })
+
+    test('forwards headers on delete', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(
+            'https://api.example.com/v1/test-org/service/service-123/version_sets/dev/',
+            ({ request }) => {
+              expect(request.headers.get('x-mongo-cluster-name')).toBe('xyz')
+              return HttpResponse.text('', { status: 204, statusText: 'No Content' })
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await resource.deleteVersionSet({
+        serviceId: serviceId('service-123'),
+        versionSetName: 'dev',
+        headers: { 'x-mongo-cluster-name': 'xyz' },
+      })
+    })
+
+    test('throws NotFoundError on 404', async () => {
+      server.use(
+        ...withMockAuth(
+          http.delete(
+            'https://api.example.com/v1/test-org/service/service-123/version_sets/missing/',
+            () => {
+              return HttpResponse.json(null, { status: 404, statusText: 'Not Found' })
+            }
+          )
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      await expect(
+        resource.deleteVersionSet({
+          serviceId: serviceId('service-123'),
+          versionSetName: 'missing',
+        })
+      ).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('convenience aliases', () => {
+    test('list delegates to getServices', async () => {
+      server.use(
+        ...withMockAuth(
+          http.get('https://api.example.com/v1/test-org/service/', () => {
+            return HttpResponse.json(mockServicesResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      const result = await resource.list()
+      expect(result).toEqual(mockServicesResponse)
+    })
+
+    test('create delegates to createService', async () => {
+      const mockResponse = { id: 'service-new' }
+
+      server.use(
+        ...withMockAuth(
+          http.post('https://api.example.com/v1/test-org/service/', () => {
+            return HttpResponse.json(mockResponse)
+          })
+        )
+      )
+
+      const client = createAmigoFetch(mockConfig)
+      const resource = new ServiceResource(client, orgId('test-org'))
+      const result = await resource.create({ body: { name: 'Test' } as any })
+      expect(result).toEqual(mockResponse as unknown)
+    })
   })
 })

--- a/tests/resources/user.test.ts
+++ b/tests/resources/user.test.ts
@@ -5,7 +5,7 @@ import { setupServer } from 'msw/node'
 import { createAmigoFetch } from '../../src/core/openapi-client'
 import { UserResource } from '../../src/resources/user'
 import { withMockAuth, mockConfig } from '../test-helpers'
-import { userId } from '../../src/core/branded-types'
+import { userId, orgId } from '../../src/core/branded-types'
 import { NotFoundError, ValidationError } from '../../src/core/errors'
 import type { components, operations } from '../../src/generated/api-types'
 
@@ -37,7 +37,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const result = await resource.getUsers()
 
       expect(result).toEqual(mockResponse as unknown)
@@ -54,7 +54,6 @@ describe('UserResource', () => {
 
             expect(params.getAll('user_id')).toEqual(['u-1', 'u-2'])
             expect(params.getAll('email')).toEqual(['a@example.com'])
-            expect(params.get('is_verified')).toBe('true')
             expect(params.get('limit')).toBe('10')
             expect(params.get('continuation_token')).toBe('5')
             expect(params.getAll('sort_by')).toEqual(['+created_at', '-created_at'])
@@ -65,12 +64,11 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
 
       const query: operations['get-users']['parameters']['query'] = {
         user_id: ['u-1', 'u-2'],
         email: ['a@example.com'],
-        is_verified: true,
         limit: 10,
         continuation_token: 5,
         sort_by: ['+created_at', '-created_at'],
@@ -92,7 +90,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const headers: operations['get-users']['parameters']['header'] = {
         'x-mongo-cluster-name': 'abc',
       }
@@ -110,7 +108,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'nonexistent-org')
+      const resource = new UserResource(client, orgId('nonexistent-org'))
       await expect(resource.getUsers()).rejects.toThrow(NotFoundError)
     })
   })
@@ -135,7 +133,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
 
       const body: components['schemas']['user__create_invited_user__Request'] = {
         first_name: 'Ada',
@@ -168,7 +166,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
 
       const body: components['schemas']['user__create_invited_user__Request'] = {
         first_name: 'Ada',
@@ -192,7 +190,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       await expect(resource.deleteUser(userId('u-1'))).resolves.toBeUndefined()
     })
 
@@ -206,7 +204,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       await expect(resource.deleteUser(userId('missing'))).rejects.toThrow(NotFoundError)
     })
   })
@@ -227,7 +225,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const body: components['schemas']['user__update_user_info__Request'] = {
         first_name: 'Grace',
         last_name: 'Hopper',
@@ -255,7 +253,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const body = { invalidBodyKey: 'abc' }
       await expect(
         resource.updateUser({ userId: userId('u-1'), body: body as any })
@@ -276,7 +274,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const result = await resource.getUserModel(userId('u-1'))
 
       expect(result).toEqual(mockResponse as unknown)
@@ -295,7 +293,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       const headers: operations['get-user-model']['parameters']['header'] = {
         'x-mongo-cluster-name': 'abc',
       }
@@ -313,7 +311,7 @@ describe('UserResource', () => {
       )
 
       const client = createAmigoFetch(mockConfig)
-      const resource = new UserResource(client, 'test-org')
+      const resource = new UserResource(client, orgId('test-org'))
       await expect(resource.getUserModel(userId('missing'))).rejects.toThrow(NotFoundError)
     })
   })

--- a/tests/type-snapshots.test.ts
+++ b/tests/type-snapshots.test.ts
@@ -16,7 +16,7 @@ function extractTypeNames(content: string): string[] {
   const names: string[] = []
   let match: RegExpExecArray | null
   while ((match = typeRegex.exec(content)) !== null) {
-    names.push(match[1])
+    names.push(match[1]!)
   }
   return names.sort()
 }
@@ -29,8 +29,8 @@ function extractOperationIds(content: string): string[] {
   // Look in the operations section
   const opsSection = content.match(/export\s+interface\s+operations\s*\{([\s\S]*?)^\}/m)
   if (opsSection) {
-    while ((match = opRegex.exec(opsSection[1])) !== null) {
-      ops.push(match[1])
+    while ((match = opRegex.exec(opsSection[1]!)) !== null) {
+      ops.push(match[1]!)
     }
   }
   return ops.sort()


### PR DESCRIPTION
## Summary
- Fix branded type casts (`orgId`, `conversationId`, etc.) across all unit + integration test files
- Remove stale `audio_format` and `is_verified` references after OpenAPI spec regen
- Add 45 new unit tests for AgentResource, ContextGraphResource, and extended ServiceResource (100% coverage on all three)
- Fix `ServiceInstance` mock missing required fields (`keyterms`, `creator`, `updated_by`)
- Update CLAUDE.md architecture section with new resources

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test:coverage` — 170 tests pass, 91.5% statements, 80.17% functions
- [x] `npm run lint` — clean
- [x] `npm run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)