### PR TITLE
fix: add gen-types step to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run gen-types
       - run: npm run docs
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- Add `npm run gen-types` before `npm run docs` in the Deploy Documentation workflow
- Without this, typedoc fails because `src/generated/api-types.ts` doesn't exist in CI (it's gitignored)

## Test plan
- [x] `npm run docs` succeeds locally
- [x] CI Test workflow still passes (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)