### PR TITLE
docs: refresh classic sdk presentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,208 +1,95 @@
 # Contributing to Amigo TypeScript SDK
 
-Thank you for your interest in contributing to the Amigo TypeScript SDK! This guide will help you get started with development, testing, and making changes to the SDK.
+Thank you for contributing to `@amigo-ai/sdk`. This repository ships the classic TypeScript SDK today while classic-to-platform migration work continues in parallel, so contributor changes should keep the existing classic package stable and well-documented.
 
 ## Development Setup
 
-1. Clone the repository
+1. Clone the repository.
 2. Install dependencies:
-   ```bash
-   npm install
-   ```
 
-## Package.json Scripts Overview
+```bash
+npm install
+```
 
-The following npm scripts are available for development:
+## Scripts
 
-### Development & Build Scripts
+### Build And Codegen
 
-- **`npm run build`** - Full build process that:
-  - Generates OpenAPI types (`scripts/gen.mjs`)
-  - Builds the project with esbuild (`scripts/build.mjs`)
-  - Compiles TypeScript declarations (`tsc --project tsconfig.build.json`)
-- **`npm run dev`** - Development build with watch mode:
-  - Generates OpenAPI types
-  - Builds with esbuild in watch mode for automatic rebuilds
-- **`npm run pack:local`** - Builds the SDK and creates a tarball in `artifacts/` for local installation.
+- `npm run gen-types` regenerates all generated types
+- `npm run gen-types:classic` regenerates classic API types
+- `npm run gen-types:platform` regenerates platform migration types
+- `npm run build` runs codegen, bundles with esbuild, and emits declarations
+- `npm run dev` runs the build in watch mode
+- `npm run docs` rebuilds the published TypeDoc output
 
-### Code Generation
+### Testing
 
-- **`npm run gen-types`** - Generates TypeScript types from the OpenAPI schema
-  - Fetches the OpenAPI specification from `https://api.amigo.ai/v1/openapi.json`
-  - Generates types in `src/generated/api-types.ts`
+- `npm test` runs the unit test project
+- `npm run test:dist` verifies the built ESM and CJS artifacts
+- `npm run test:integration` runs live API integration tests
+- `npm run test:coverage` runs unit coverage
 
-### Testing Scripts
+### Code Quality
 
-- **`npm run test`** - Runs all **unit** tests using Vitest
-- **`npm run test:coverage`** - Runs all **unit** tests using Vitest and generates coverage report
-- **`npm run test:integration`** - Runs all **integration** tests using Vitest
-
-### Code Quality Scripts
-
-- **`npm run lint`** - Lints TypeScript files with ESLint (zero warnings policy)
-- **`npm run lint:fix`**: Automatically fixes ESLint issues in `src`.
-- **`npm run format`** - Checks code formatting with Prettier
-- **`npm run format:write`** - Automatically formats code with Prettier
+- `npm run lint` runs ESLint with zero warnings
+- `npm run format` checks formatting with Prettier
+- `npm run format:write` applies formatting
 
 ## Testing
 
-This project uses **Vitest** as the testing framework. Test files should follow the naming convention `*.test.ts` or `*.spec.ts`.
-
-### Test Configuration
-
-- Tests are located in the `tests/` directory
-- Test configuration is in `vitest.config.ts`
-- Tests run in Node.js environment
-- Global test utilities are available
-- Coverage reports exclude generated files and configuration
-
-### Running Tests
+This repository uses Vitest.
 
 ```bash
-# Run all tests once
-npm run test
-
-# Run integration tests which hit live API endpoints
+npm test
+npm run test:dist
 npm run test:integration
-
-# Run tests in watch mode during development
-npm run test:watch
-
-# Run tests with coverage report
 npm run test:coverage
 ```
 
-### Writing Tests
+Integration tests require valid Amigo API credentials in the environment.
 
-- Place test files in the `tests/` directory
-- Place integration test files in the `tests/integration` directory
-- Test helpers are available in `tests/test-helpers.ts`
-- The project uses MSW (Mock Service Worker) for API mocking
+## Type Generation
 
-Example test structure:
+Code generation is intentionally split:
 
-```typescript
-import { describe, it, expect } from 'vitest'
-import { YourModule } from '../src/your-module.js'
+- Classic API output is generated into `src/generated/`
+- Platform migration output is generated into `src/generated/platform-api-types.ts`
 
-describe('YourModule', () => {
-  it('should do something', () => {
-    // Your test here
-    expect(true).toBe(true)
-  })
-})
-```
-
-## OpenAPI Type Generation
-
-The SDK automatically generates TypeScript types from the Amigo API's OpenAPI specification.
-
-### How it Works
-
-1. The `scripts/gen.mjs` script fetches the OpenAPI schema from `https://api.amigo.ai/v1/openapi.json`
-2. Uses `openapi-typescript` to convert the schema into TypeScript types
-3. Generates types in `src/generated/api-types.ts`
-4. These types are used throughout the SDK for type safety
-
-### Regenerating Types
-
-Types are automatically regenerated during the build process, but you can manually regenerate them:
-
-```bash
-npm run gen-types
-```
-
-### Important Notes
-
-- **Never manually edit** files in `src/generated/` - they will be overwritten
-- Types are regenerated on every build to stay in sync with the API
-- The generated types are excluded from test coverage
-
-## Development Workflow
-
-1. **Start development**: `npm run dev` (builds and watches for changes)
-2. **Write tests**: Add tests in the `tests/` directory
-3. **Run tests**: `npm run test:watch` while developing
-4. **Lint and format**: `npm run lint` and `npm run format:write`
-5. **Build**: `npm run build` before submitting
+Never edit generated files manually.
 
 ## Project Structure
 
-```
+```text
 src/
-├── core/           # Core SDK functionality
-├── generated/      # Auto-generated OpenAPI types (do not edit)
-├── resources/      # API resource modules
-└── index.ts        # Main entry point
+├── core/            # auth, errors, retry, helpers
+├── generated/       # generated classic OpenAPI types
+├── platform/        # platform migration resources and types
+├── resources/       # classic API resources
+└── index.ts         # public package entry point
 
 tests/
-├── integration/    # Integration tests
-├── resources/      # Tests for resource modules
-└── *.test.ts       # Core functionality tests
+├── integration/     # live API tests
+├── resources/       # resource-level unit tests
+└── *.test.ts        # core package tests
+
+scripts/
+├── build.mjs
+├── gen-all.mjs
+├── gen-classic.mjs
+└── gen-platform.mjs
 ```
 
-## Pull Request Guidelines
+## Pull Requests
 
-1. Ensure all tests pass: `npm test`
-2. Lint your code: `npm run lint`
-3. Format your code: `npm run format:write`
-4. Build successfully: `npm run build`
-5. Add tests for new functionality
-6. Update documentation if needed
+Before opening a PR:
 
-## Release Process
+1. Run `npm run format:write`
+2. Run `npm run lint`
+3. Run `npm test`
+4. Run `npm run build`
+5. Run `npm run test:dist` for package-surface changes
+6. Update README or examples if customer-visible behavior changed
 
-Releases are handled via GitHub Actions. The release workflow:
+## Release Notes
 
-1. Reuses the test workflow to validate the build
-2. Regenerates OpenAPI types
-3. Bumps the version
-4. Builds and packs the package
-5. Publishes to npm (unless in dry run)
-6. Commits the version bump, creates a tag, and a GitHub Release
-
-### Required Repository Secrets
-
-Configure these secrets in your repository settings:
-
-- `NPM_TOKEN`: Token for publishing to npm
-- `CODECOV_TOKEN`: Token for Codecov uploads (used by CI test workflow)
-- `RELEASE_BOT_APP_ID`: GitHub App ID used to create tags/releases
-- `RELEASE_BOT_PRIVATE_KEY`: GitHub App private key (PEM) for the release bot
-
-### Auto-Release (OpenAPI changes)
-
-When the backend OpenAPI spec changes, the SDK can auto-release a new version.
-
-- Trigger: a `repository_dispatch` event with type `openapi-updated`
-- Detect job: fetches the provided `spec_url` (or defaults to `https://api.amigo.ai/v1/openapi.json`), normalizes and compares against `specs/openapi-baseline.json`
-- If changed: invokes the release workflow with `version_type=minor` and passes `spec_url` (supports `dry_run`)
-- Release workflow: regenerates types, bumps version, builds, publishes to npm, pushes tag, and creates a GitHub release
-
-Manual trigger example (repository_dispatch) using GitHub CLI:
-
-```bash
-# Values that mirror the workflow
-OWNER="amigo-ai"
-BACKEND_REPO="$OWNER/backend"
-COMMIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo manual-test)"
-RUN_ID="$(date +%s)"  # stand-in for GitHub Actions run_id
-
-for repo in amigo-typescript-sdk amigo-python-sdk; do
-  echo "Notifying $repo..."
-  gh api "repos/$OWNER/$repo/dispatches" \
-    --method POST \
-    --header 'Accept: application/vnd.github+json' \
-    --input - <<EOF || echo "⚠️  Failed to notify $repo"
-{
-  "event_type": "openapi-updated",
-  "client_payload": {
-    "spec_url": "https://api.amigo.ai/v1/openapi.json",
-    "commit_sha": "$COMMIT_SHA",
-    "backend_repo": "$BACKEND_REPO",
-    "backend_run_id": "$RUN_ID"
-  }
-}
-EOF
-done
-```
+Releases are handled by GitHub Actions. If you change public package behavior, examples, or generated API surface, include enough context in the PR description for maintainers to produce accurate release notes.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,36 @@
-# Amigo TypeScript SDK
+# @amigo-ai/sdk
 
 [![Tests](https://github.com/amigo-ai/amigo-typescript-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/amigo-ai/amigo-typescript-sdk/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/amigo-ai/amigo-typescript-sdk/graph/badge.svg?token=PQU5JBU941)](https://codecov.io/gh/amigo-ai/amigo-typescript-sdk)
 [![npm version](https://img.shields.io/npm/v/%40amigo-ai%2Fsdk?logo=npm)](https://www.npmjs.com/package/@amigo-ai/sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-The official TypeScript SDK for the Amigo API, providing a simple and intuitive interface to interact with Amigo's AI services.
+Official TypeScript SDK for the Amigo API.
+
+Typed from the Amigo OpenAPI schema, shipped as both ESM and CommonJS, and designed for the classic org-scoped API used by existing Amigo integrations.
+
+## Documentation
+
+- [Product Docs](https://docs.amigo.ai)
+- [Developer Guide](https://docs.amigo.ai/developer-guide)
+- [Examples](https://github.com/amigo-ai/amigo-typescript-sdk/tree/main/examples)
+- [Changelog](https://github.com/amigo-ai/amigo-typescript-sdk/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/amigo-ai/amigo-typescript-sdk/blob/main/CONTRIBUTING.md)
+
+## Status
+
+This package remains the supported SDK for the classic Amigo API. The Amigo Platform API is the long-term home for new workspace-scoped capabilities, but classic customers are not being asked to make an abrupt rewrite. As equivalent platform surfaces become available, Amigo will publish a migration path and upgrade guidance before recommending a move.
+
+Classic is not end-of-life. Existing integrations can continue to build on `@amigo-ai/sdk` while platform coverage expands.
+
+## Choose The Right SDK
+
+| If you need                                                    | Use                                                                                   |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| The current org-scoped Amigo API used by existing integrations | `@amigo-ai/sdk`                                                                       |
+| New workspace-scoped Platform API integrations                 | [`@amigo-ai/platform-sdk`](https://github.com/amigo-ai/amigo-platform-typescript-sdk) |
 
 ## Installation
-
-Install the SDK using npm:
 
 ```bash
 npm install @amigo-ai/sdk
@@ -17,12 +38,9 @@ npm install @amigo-ai/sdk
 
 ## Quick Start
 
-### ES Modules (ESM)
-
 ```typescript
 import { AmigoClient } from '@amigo-ai/sdk'
 
-// Initialize the client
 const client = new AmigoClient({
   apiKey: 'your-api-key',
   apiKeyId: 'your-api-key-id',
@@ -30,108 +48,74 @@ const client = new AmigoClient({
   orgId: 'your-organization-id',
 })
 
-// List recent conversations
-async function example() {
-  try {
-    const conversations = await client.conversations.getConversations({
-      limit: 10,
-      sort_by: ['-created_at'],
-    })
-    console.log('Conversations:', conversations)
-  } catch (error) {
-    console.error('Error:', error)
-  }
-}
-
-example()
-```
-
-### CommonJS (CJS)
-
-```javascript
-const { AmigoClient } = require('@amigo-ai/sdk')
-
-const client = new AmigoClient({
-  apiKey: 'your-api-key',
-  apiKeyId: 'your-api-key-id',
-  userId: 'user-id',
-  orgId: 'your-organization-id',
+const conversations = await client.conversations.getConversations({
+  limit: 10,
+  sort_by: ['-created_at'],
 })
+
+console.log(conversations.conversations.map(conversation => conversation.id))
 ```
 
-## Examples
-
-- **Conversation management**:
-  - [Basic conversation](examples/conversation/basic-conversation.ts)
-  - [Streaming conversation events](examples/conversation/conversation-events.ts)
-- **User management**:
-  - [User management examples](examples/user/user-management.ts)
+ESM and CommonJS are both supported. See the [examples directory](https://github.com/amigo-ai/amigo-typescript-sdk/tree/main/examples) for runnable examples.
 
 ## Configuration
 
-The SDK requires the following configuration parameters:
+| Option     | Type           | Required | Description                                                   |
+| ---------- | -------------- | -------- | ------------------------------------------------------------- |
+| `apiKey`   | `string`       | Yes      | API key from the Amigo dashboard                              |
+| `apiKeyId` | `string`       | Yes      | API key ID paired with `apiKey`                               |
+| `userId`   | `string`       | Yes      | User ID on whose behalf the request is made                   |
+| `orgId`    | `string`       | Yes      | Organization ID for the classic API                           |
+| `baseUrl`  | `string`       | No       | Override the API base URL. Defaults to `https://api.amigo.ai` |
+| `retry`    | `RetryOptions` | No       | Retry policy overrides for transient HTTP failures            |
 
-| Parameter  | Type   | Required | Description                                                    |
-| ---------- | ------ | -------- | -------------------------------------------------------------- |
-| `apiKey`   | string | ✅       | API key from Amigo dashboard                                   |
-| `apiKeyId` | string | ✅       | API key ID from Amigo dashboard                                |
-| `userId`   | string | ✅       | User ID on whose behalf the request is made                    |
-| `orgId`    | string | ✅       | Your organization ID                                           |
-| `baseUrl`  | string | ❌       | Base URL of the Amigo API (defaults to `https://api.amigo.ai`) |
+## What This SDK Covers
 
-### Getting Your API Credentials
+- Conversations, including NDJSON event streaming
+- Services and version-set operations
+- Users and organizations
+- Agents and context graphs
+- Webhook helpers, rate-limit parsing, and typed SDK errors
 
-1. **API Key & API Key ID**: Generate these from your Amigo admin dashboard or programmatically using the API
-2. **Organization ID**: Found in your Amigo dashboard URL or organization settings
-3. **User ID**: The ID of the user you want to impersonate for API calls
+## Generated Types
 
-For detailed instructions on generating API keys, see the [Authentication Guide](https://docs.amigo.ai/developer-guide).
-
-### API compatibility
-
-This SDK auto-generates its types from the latest Amigo OpenAPI schema. As a result, only the latest published SDK version is guaranteed to match the current API. If you pin to an older version, it may not include the newest endpoints or fields.
-
-## Generated types
-
-The SDK ships with TypeScript types generated from the latest OpenAPI schema and re-exports them for convenience.
-
-- **Importing types**:
+The package re-exports the generated OpenAPI types so you can type application code directly from the API contract:
 
 ```typescript
 import type { components, operations, paths } from '@amigo-ai/sdk'
 
-// Example: response types
-type Conversation = components['schemas']['Conversation']
-
-// Example: operation params
-type GetConversationsParams = operations['getConversations']['parameters']['query']
+type Conversation = components['schemas']['ConversationInstance']
+type GetConversationsQuery = operations['get-conversations']['parameters']['query']
 ```
 
 ## Retries
 
-The HTTP client includes sensible, configurable retries:
+The HTTP client retries transient failures with sensible defaults:
 
-- **Defaults**:
-  - max attempts: 3
-  - backoff base: 250ms (exponential with full jitter)
-  - max delay per attempt: 30s
-  - retry on status: {408, 429, 500, 502, 503, 504}
-  - retry on methods: {GET}
-  - special-case: POST is retried on 429 when `Retry-After` is present
+- Max attempts: `3`
+- Backoff base: `250ms` with full jitter
+- Max delay per attempt: `30s`
+- Statuses: `408`, `429`, `500`, `502`, `503`, `504`
+- Methods: `GET`, plus `POST` on `429` when `Retry-After` is present
 
 ## Error Handling
 
-The SDK provides typed error handling:
-
 ```typescript
-import { AmigoClient, errors } from '@amigo-ai/sdk'
+import { AmigoClient, AuthenticationError, NetworkError } from '@amigo-ai/sdk'
 
 try {
-  const result = await client.organizations.getOrganization('org-id')
+  const client = new AmigoClient({
+    apiKey: 'your-api-key',
+    apiKeyId: 'your-api-key-id',
+    userId: 'user-id',
+    orgId: 'your-organization-id',
+  })
+
+  await client.organizations.getOrganization()
 } catch (error) {
-  if (error instanceof errors.AuthenticationError) {
+  if (error instanceof AuthenticationError) {
     console.error('Authentication failed:', error.message)
-  } else if (error instanceof errors.NetworkError) {
+  } else if (error instanceof NetworkError) {
     console.error('Network error:', error.message)
   } else {
     console.error('Unexpected error:', error)
@@ -139,41 +123,6 @@ try {
 }
 ```
 
-## Troubleshooting
-
-### Authentication errors
-
-- **`AuthenticationError: Authentication failed`**: Verify your `apiKey` and `apiKeyId` are correct and haven't been revoked. Regenerate them from the Amigo dashboard if needed.
-- **Token refresh failures**: The SDK refreshes tokens automatically 5 minutes before expiry. If this persists, check that your system clock is accurate.
-
-### Configuration issues
-
-- **`ConfigurationError`**: Ensure all required fields (`apiKey`, `apiKeyId`, `userId`, `orgId`) are provided when constructing `AmigoClient`.
-
-### Connection issues
-
-- **`NetworkError` or timeouts**: Check your network connectivity and that `https://api.amigo.ai` is reachable. If behind a corporate proxy, configure your environment's proxy settings.
-- **`RateLimitError`**: The SDK retries automatically on 429 responses with `Retry-After` headers. If you consistently hit rate limits, reduce request frequency or contact support.
-
-### TypeScript / import issues
-
-- **`Cannot find module '@amigo-ai/sdk'`**: Ensure the package is installed: `npm install @amigo-ai/sdk`.
-- **Type errors with generated types**: Update to the latest SDK version (`npm install @amigo-ai/sdk@latest`) — types are regenerated from the OpenAPI spec on each release.
-- **ESM/CJS import issues**: The SDK supports both. Use `import { AmigoClient } from '@amigo-ai/sdk'` for ESM or `const { AmigoClient } = require('@amigo-ai/sdk')` for CJS. Ensure your `tsconfig.json` has compatible `moduleResolution` settings.
-
-### Streaming issues
-
-- **NDJSON stream not yielding events**: Ensure you're using `for await` to consume the async generator returned by `createConversation` and `interactWithConversation`.
-
-## Documentation
-
-- **Developer Guide**: [https://docs.amigo.ai/developer-guide](https://docs.amigo.ai/developer-guide)
-- **API Reference**: [https://docs.amigo.ai/api-reference](https://docs.amigo.ai/api-reference)
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
 ## Support
 
-For questions, issues, or feature requests, please visit our [GitHub repository](https://github.com/amigo-ai/amigo-typescript-sdk) or contact support through the Amigo dashboard.
+Use the [issue tracker](https://github.com/amigo-ai/amigo-typescript-sdk/issues) for bugs and feature requests. For vulnerability reports, see [SECURITY.md](https://github.com/amigo-ai/amigo-typescript-sdk/blob/main/SECURITY.md).


### PR DESCRIPTION
## Summary
- refresh the public README to better match the platform SDK presentation
- clarify that the classic SDK remains supported while platform migration guidance is prepared
- tighten the contributing guide for a more polished public-facing repo surface

## Testing
- not run (docs-only changes)