### PR TITLE
docs: elevate classic sdk front door and stabilize workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./assets/readme/classic-ts-banner.svg" alt="Classic TypeScript SDK banner" width="100%" />
+</p>
+
 <h1 align="center">@amigo-ai/sdk</h1>
 
 <p align="center">Official TypeScript SDK for the classic Amigo API.</p>
@@ -23,6 +27,12 @@
 
 Typed from the Amigo OpenAPI schema, shipped as ESM and CommonJS, and used by current org-scoped Amigo integrations.
 
+## Classic API Context
+
+The classic SDK is the typed client boundary between your application and the org-scoped Amigo API. It remains the right fit for current integrations that depend on the classic resource model while platform-native coverage expands.
+
+![Classic TypeScript SDK architecture](./assets/readme/classic-ts-architecture.svg)
+
 ## Product Status
 
 `@amigo-ai/sdk` remains the supported TypeScript client for the classic Amigo API.
@@ -35,10 +45,6 @@ The Platform API is the long-term home for new workspace-scoped capabilities, bu
 | --- | --- |
 | The current org-scoped Amigo API used by existing integrations | `@amigo-ai/sdk` |
 | New workspace-scoped Platform API integrations | [`@amigo-ai/platform-sdk`](https://github.com/amigo-ai/amigo-platform-typescript-sdk) |
-
-## API Context
-
-This SDK is the typed client boundary between your application and the classic Amigo API at `https://api.amigo.ai`. It covers the current org-scoped resources used by existing Amigo deployments: conversations, services, organizations, users, agents, context graphs, webhooks, and streaming events.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
 </p>
 
-Typed from the Amigo OpenAPI schema, shipped as ESM and CommonJS, and used by current org-scoped Amigo integrations.
+Typed from the committed classic OpenAPI snapshot, shipped as ESM and CommonJS, and used by current org-scoped Amigo integrations.
 
 ## Classic API Context
 
@@ -41,20 +41,20 @@ The Platform API is the long-term home for new workspace-scoped capabilities, bu
 
 ## Choose The Right SDK
 
-| If you need | Use |
-| --- | --- |
-| The current org-scoped Amigo API used by existing integrations | `@amigo-ai/sdk` |
-| New workspace-scoped Platform API integrations | [`@amigo-ai/platform-sdk`](https://github.com/amigo-ai/amigo-platform-typescript-sdk) |
+| If you need                                                    | Use                                                                                   |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| The current org-scoped Amigo API used by existing integrations | `@amigo-ai/sdk`                                                                       |
+| New workspace-scoped Platform API integrations                 | [`@amigo-ai/platform-sdk`](https://github.com/amigo-ai/amigo-platform-typescript-sdk) |
 
 ## Documentation
 
-| Need | Best entry point |
-| --- | --- |
-| Product overview and deployment context | [docs.amigo.ai](https://docs.amigo.ai/) |
-| Integration guidance and developer docs | [Developer Guide](https://docs.amigo.ai/developer-guide) |
-| Generated API reference | [amigo-ai.github.io/amigo-typescript-sdk](https://amigo-ai.github.io/amigo-typescript-sdk/) |
-| Runnable examples | [examples/](https://github.com/amigo-ai/amigo-typescript-sdk/tree/main/examples) |
-| Release history | [CHANGELOG.md](https://github.com/amigo-ai/amigo-typescript-sdk/blob/main/CHANGELOG.md) |
+| Need                                    | Best entry point                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Product overview and deployment context | [docs.amigo.ai](https://docs.amigo.ai/)                                                     |
+| Integration guidance and developer docs | [Developer Guide](https://docs.amigo.ai/developer-guide)                                    |
+| Generated API reference                 | [amigo-ai.github.io/amigo-typescript-sdk](https://amigo-ai.github.io/amigo-typescript-sdk/) |
+| Runnable examples                       | [examples/](https://github.com/amigo-ai/amigo-typescript-sdk/tree/main/examples)            |
+| Release history                         | [CHANGELOG.md](https://github.com/amigo-ai/amigo-typescript-sdk/blob/main/CHANGELOG.md)     |
 
 ## Installation
 
@@ -79,19 +79,19 @@ const conversations = await client.conversations.getConversations({
   sort_by: ['-created_at'],
 })
 
-console.log(conversations.conversations.map((conversation) => conversation.id))
+console.log(conversations.conversations.map(conversation => conversation.id))
 ```
 
 ## Configuration
 
-| Option | Type | Required | Description |
-| --- | --- | --- | --- |
-| `apiKey` | `string` | Yes | API key from the Amigo dashboard |
-| `apiKeyId` | `string` | Yes | API key ID paired with `apiKey` |
-| `userId` | `string` | Yes | User ID on whose behalf the request is made |
-| `orgId` | `string` | Yes | Organization ID for the classic API |
-| `baseUrl` | `string` | No | Override the API base URL. Defaults to `https://api.amigo.ai` |
-| `retry` | `RetryOptions` | No | Retry policy overrides for transient HTTP failures |
+| Option     | Type           | Required | Description                                                   |
+| ---------- | -------------- | -------- | ------------------------------------------------------------- |
+| `apiKey`   | `string`       | Yes      | API key from the Amigo dashboard                              |
+| `apiKeyId` | `string`       | Yes      | API key ID paired with `apiKey`                               |
+| `userId`   | `string`       | Yes      | User ID on whose behalf the request is made                   |
+| `orgId`    | `string`       | Yes      | Organization ID for the classic API                           |
+| `baseUrl`  | `string`       | No       | Override the API base URL. Defaults to `https://api.amigo.ai` |
+| `retry`    | `RetryOptions` | No       | Retry policy overrides for transient HTTP failures            |
 
 ### Runtime Requirements
 
@@ -106,6 +106,12 @@ import type { components, operations, paths } from '@amigo-ai/sdk'
 
 type Conversation = components['schemas']['ConversationInstance']
 type GetConversationsQuery = operations['get-conversations']['parameters']['query']
+```
+
+Public builds are generated from the committed [`specs/openapi-baseline.json`](./specs/openapi-baseline.json) snapshot in this repo so type output stays deterministic across machines and CI runs. When you need to refresh that snapshot, run:
+
+```bash
+npm run openapi:sync
 ```
 
 ## Retries

--- a/assets/readme/classic-ts-architecture.svg
+++ b/assets/readme/classic-ts-architecture.svg
@@ -1,0 +1,33 @@
+<svg width="1200" height="460" viewBox="0 0 1200 460" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="460" rx="28" fill="#F5F9FF"/>
+  <text x="68" y="72" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700">Classic SDK context</text>
+  <text x="68" y="109" fill="#516B8A" font-family="Arial, Helvetica, sans-serif" font-size="20">Org-scoped runtime → SDK → classic Amigo API → current resources</text>
+  <rect x="68" y="166" width="232" height="176" rx="24" fill="#FFFFFF" stroke="#D7E4F7" stroke-width="2"/>
+  <text x="101" y="214" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700">Your runtime</text>
+  <text x="101" y="258" fill="#516B8A" font-family="Arial, Helvetica, sans-serif" font-size="19">Node app</text>
+  <text x="101" y="288" fill="#516B8A" font-family="Arial, Helvetica, sans-serif" font-size="19">Worker</text>
+  <text x="101" y="318" fill="#516B8A" font-family="Arial, Helvetica, sans-serif" font-size="19">Backend service</text>
+  <rect x="364" y="132" width="244" height="244" rx="28" fill="#0B2742"/>
+  <text x="402" y="196" fill="#BCE9FF" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" letter-spacing="0.14em">TYPESCRIPT SDK</text>
+  <text x="402" y="246" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="700">@amigo-ai/sdk</text>
+  <text x="402" y="293" fill="#C9DAF4" font-family="Arial, Helvetica, sans-serif" font-size="19">Auth, retries,</text>
+  <text x="402" y="322" fill="#C9DAF4" font-family="Arial, Helvetica, sans-serif" font-size="19">typed resources,</text>
+  <text x="402" y="351" fill="#C9DAF4" font-family="Arial, Helvetica, sans-serif" font-size="19">stream helpers</text>
+  <rect x="672" y="132" width="224" height="244" rx="28" fill="#1657C0"/>
+  <text x="706" y="196" fill="#DDF4FF" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" letter-spacing="0.14em">CLASSIC API</text>
+  <text x="706" y="245" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="700">api.amigo.ai</text>
+  <text x="706" y="292" fill="#E4EEFF" font-family="Arial, Helvetica, sans-serif" font-size="19">Org-scoped</text>
+  <text x="706" y="321" fill="#E4EEFF" font-family="Arial, Helvetica, sans-serif" font-size="19">resource model</text>
+  <rect x="946" y="102" width="184" height="82" rx="22" fill="#FFFFFF" stroke="#D7E4F7" stroke-width="2"/>
+  <rect x="946" y="194" width="184" height="82" rx="22" fill="#FFFFFF" stroke="#D7E4F7" stroke-width="2"/>
+  <rect x="946" y="286" width="184" height="82" rx="22" fill="#FFFFFF" stroke="#D7E4F7" stroke-width="2"/>
+  <text x="977" y="145" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">Conversations</text>
+  <text x="977" y="237" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">Services + users</text>
+  <text x="977" y="329" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">Agents + graphs</text>
+  <path d="M300 254H346" stroke="#89A9D6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M608 254H654" stroke="#89A9D6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M896 254H928" stroke="#89A9D6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M928 254V145H946" stroke="#89A9D6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M928 254H946" stroke="#89A9D6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M928 254V327H946" stroke="#89A9D6" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/readme/classic-ts-banner.svg
+++ b/assets/readme/classic-ts-banner.svg
@@ -1,0 +1,31 @@
+<svg width="1600" height="520" viewBox="0 0 1600 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="120" y1="40" x2="1460" y2="500" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#07111F"/>
+      <stop offset="0.45" stop-color="#0B2742"/>
+      <stop offset="1" stop-color="#1657C0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="1112" y1="44" x2="1374" y2="280" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#91F2FF"/>
+      <stop offset="1" stop-color="#7AB3FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="520" rx="36" fill="url(#bg)"/>
+  <circle cx="1290" cy="120" r="120" fill="url(#accent)" fill-opacity="0.24"/>
+  <circle cx="1455" cy="391" r="167" fill="#7AB3FF" fill-opacity="0.12"/>
+  <circle cx="1160" cy="401" r="88" fill="#91F2FF" fill-opacity="0.16"/>
+  <rect x="92" y="88" width="190" height="38" rx="19" fill="#D8F5FF" fill-opacity="0.14" stroke="#91F2FF" stroke-opacity="0.45"/>
+  <text x="121" y="113" fill="#DDF8FF" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700" letter-spacing="0.18em">CLASSIC API</text>
+  <text x="92" y="206" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="66" font-weight="700">@amigo-ai/sdk</text>
+  <text x="92" y="266" fill="#D5E7FF" font-family="Arial, Helvetica, sans-serif" font-size="28">TypeScript client for the current org-scoped Amigo API.</text>
+  <text x="92" y="308" fill="#D5E7FF" font-family="Arial, Helvetica, sans-serif" font-size="28">Conversations, services, users, agents, context graphs, and streaming.</text>
+  <rect x="92" y="364" width="310" height="60" rx="18" fill="#FFFFFF"/>
+  <text x="123" y="402" fill="#0B2742" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700">Migration path planned</text>
+  <rect x="427" y="364" width="360" height="60" rx="18" fill="#9AD7FF" fill-opacity="0.14" stroke="#91F2FF" stroke-opacity="0.45"/>
+  <text x="457" y="402" fill="#E9F6FF" font-family="Arial, Helvetica, sans-serif" font-size="24" font-weight="700">ESM + CJS, typed from OpenAPI</text>
+  <rect x="1008" y="170" width="340" height="188" rx="28" fill="#08192C" fill-opacity="0.58" stroke="#91F2FF" stroke-opacity="0.25"/>
+  <text x="1047" y="220" fill="#E9F6FF" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">Used today by existing</text>
+  <text x="1047" y="252" fill="#E9F6FF" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">Amigo integrations</text>
+  <text x="1047" y="305" fill="#A7CFFF" font-family="Arial, Helvetica, sans-serif" font-size="20">Stable front door for classic API customers</text>
+  <text x="1047" y="338" fill="#A7CFFF" font-family="Arial, Helvetica, sans-serif" font-size="20">while platform-native coverage expands</text>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amigo-ai/sdk",
-  "version": "0.100.1",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amigo-ai/sdk",
-      "version": "0.100.1",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.14.0"
@@ -30,8 +30,11 @@
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      },
       "optionalDependencies": {
-        "@rollup/rollup-darwin-arm64": "^4.34.8"
+        "@rollup/rollup-darwin-arm64": "^4.59.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "gen-types": "node scripts/gen.mjs",
+    "openapi:sync": "node scripts/sync-openapi.mjs",
     "test": "vitest run --project unit",
     "test:dist": "vitest run --project dist",
     "test:integration": "vitest run --project integration",
@@ -96,5 +97,8 @@
   },
   "dependencies": {
     "openapi-fetch": "^0.14.0"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "^4.59.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "files": [
+    "assets",
     "dist",
     "README.md",
     "LICENSE"

--- a/scripts/gen.mjs
+++ b/scripts/gen.mjs
@@ -1,120 +1,112 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import openapiTS, { astToString } from 'openapi-typescript'
-import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname } from 'node:path'
 
-const schemaUrl = 'https://api.amigo.ai/v1/openapi.json'
-const outTypesFile = 'src/generated/api-types.ts'
+const REPO_ROOT = process.cwd()
+const DEFAULT_SPEC = path.resolve(REPO_ROOT, 'specs/openapi-baseline.json')
+const OUT_FILE = path.resolve(REPO_ROOT, 'src/generated/api-types.ts')
+const args = process.argv.slice(2)
 
-/* -------- Fetch and fix the schema -------- */
-console.log('📥 Fetching OpenAPI schema...')
-
-let schema
-try {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 30000)
-
-  const response = await fetch(schemaUrl, { signal: controller.signal })
-  clearTimeout(timeout)
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} ${response.statusText}`)
-  }
-  schema = await response.json()
-} catch (err) {
-  if (err.name === 'AbortError') {
-    throw new Error(`Failed to fetch schema: request timed out after 30s`)
-  }
-  throw new Error(`Failed to fetch schema: ${err.message}`)
+function getArgValue(name) {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
 }
 
-// Fix broken discriminator mappings by removing references to non-existent schemas.
-// The API sometimes has discriminator mappings that point to schemas that don't exist,
-// which causes openapi-typescript to fail during validation.
-const existingSchemas = new Set(Object.keys(schema.components?.schemas || {}))
-let brokenMappingsCount = 0
+function resolveSpecSource() {
+  const specArg = getArgValue('--spec')
+  if (specArg) {
+    const resolvedPath = path.resolve(REPO_ROOT, specArg)
+    console.log(`Using explicit spec: ${resolvedPath}`)
+    return resolvedPath
+  }
 
-function fixDiscriminatorMappings(obj) {
-  if (!obj || typeof obj !== 'object') return
+  if (fs.existsSync(DEFAULT_SPEC)) {
+    console.log(`Using committed spec snapshot: ${DEFAULT_SPEC}`)
+    return DEFAULT_SPEC
+  }
 
-  if (obj.discriminator?.mapping) {
-    const mapping = obj.discriminator.mapping
-    for (const [key, ref] of Object.entries(mapping)) {
-      // Extract schema name from $ref like "#/components/schemas/SchemaName"
-      const schemaName = ref.replace('#/components/schemas/', '')
-      if (!existingSchemas.has(schemaName)) {
-        delete mapping[key]
-        brokenMappingsCount++
-        console.warn(`⚠️  Removing broken discriminator mapping: ${key} -> ${ref}`)
+  throw new Error(
+    'No committed OpenAPI snapshot found at specs/openapi-baseline.json. Run `npm run openapi:sync` first.',
+  )
+}
+
+async function loadSpec(specSource) {
+  const raw = fs.readFileSync(specSource, 'utf-8')
+  const document = JSON.parse(raw)
+
+  if (!document || typeof document !== 'object' || typeof document.openapi !== 'string') {
+    throw new Error(`Invalid OpenAPI document: ${specSource}`)
+  }
+
+  return document
+}
+
+function patchOpenApiDocument(schema) {
+  const existingSchemas = new Set(Object.keys(schema.components?.schemas || {}))
+
+  function fixDiscriminatorMappings(obj) {
+    if (!obj || typeof obj !== 'object') return
+
+    if (obj.discriminator?.mapping) {
+      const mapping = obj.discriminator.mapping
+      for (const [key, ref] of Object.entries(mapping)) {
+        const schemaName = ref.replace('#/components/schemas/', '')
+        if (!existingSchemas.has(schemaName)) {
+          delete mapping[key]
+          console.warn(`Removing broken discriminator mapping: ${key} -> ${ref}`)
+        }
+      }
+    }
+
+    for (const value of Object.values(obj)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          fixDiscriminatorMappings(item)
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        fixDiscriminatorMappings(value)
       }
     }
   }
 
-  // Recursively process nested objects and arrays
-  for (const value of Object.values(obj)) {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        fixDiscriminatorMappings(item)
+  fixDiscriminatorMappings(schema)
+
+  const seenOperationIds = new Map()
+  for (const [pathKey, methods] of Object.entries(schema.paths || {})) {
+    for (const [method, operation] of Object.entries(methods)) {
+      if (typeof operation !== 'object' || !operation.operationId) continue
+
+      const operationId = operation.operationId
+      if (seenOperationIds.has(operationId)) {
+        const nextOperationId = `${operationId}-${method}`
+        console.warn(
+          `Fixing duplicate operationId: ${operationId} -> ${nextOperationId} (${method.toUpperCase()} ${pathKey})`,
+        )
+        operation.operationId = nextOperationId
+      } else {
+        seenOperationIds.set(operationId, true)
       }
-    } else if (typeof value === 'object' && value !== null) {
-      fixDiscriminatorMappings(value)
     }
   }
+
+  return schema
 }
 
-fixDiscriminatorMappings(schema)
+const specSource = resolveSpecSource()
+console.log(`Generating types from: ${specSource}`)
 
-if (brokenMappingsCount > 0) {
-  console.warn(`⚠️  Removed ${brokenMappingsCount} broken discriminator mapping(s) from schema`)
-}
+const schema = patchOpenApiDocument(await loadSpec(specSource))
+const ast = await openapiTS(schema, { defaultNonNullable: false })
 
-// Fix duplicate operationIds by appending the HTTP method to make them unique.
-// The API sometimes reuses the same operationId across different HTTP methods on the same path.
-const seenOperationIds = new Map()
-let duplicateFixCount = 0
-
-for (const [path, methods] of Object.entries(schema.paths || {})) {
-  for (const [method, op] of Object.entries(methods)) {
-    if (typeof op !== 'object' || !op.operationId) continue
-    const key = op.operationId
-    if (seenOperationIds.has(key)) {
-      const newId = `${key}-${method}`
-      console.warn(
-        `⚠️  Fixing duplicate operationId: ${key} -> ${newId} (${method.toUpperCase()} ${path})`
-      )
-      op.operationId = newId
-      duplicateFixCount++
-    } else {
-      seenOperationIds.set(key, `${method.toUpperCase()} ${path}`)
-    }
-  }
-}
-
-if (duplicateFixCount > 0) {
-  console.warn(`⚠️  Fixed ${duplicateFixCount} duplicate operationId(s) in schema`)
-}
-
-/* -------- TypeScript types -------- */
-await mkdir(dirname(outTypesFile), { recursive: true })
-
-let ast
-try {
-  ast = await openapiTS(schema, { defaultNonNullable: false })
-} catch (err) {
-  throw new Error(`Failed to generate TypeScript types: ${err.message}`)
-}
-
-// Convert AST to string and apply targeted overrides
 let code = astToString(ast)
 
-// Override ONLY the `interact-with-conversation` operation's requestBody to `any`
 const interactOpPattern = /(\"interact-with-conversation\":\s*\{[\s\S]*?)(requestBody\?:\s*never;)/
 code = code.replace(interactOpPattern, '$1requestBody?: any;')
-
-// Strip noisy schema name prefix for cleaner consumer types
-// e.g., components["schemas"]["src__app__endpoints__conversation__create_conversation__Request"]
-//   => components["schemas"]["conversation__create_conversation__Request"]
 code = code.replace(/src__app__endpoints__/g, '')
 
-await writeFile(outTypesFile, code)
+fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true })
+fs.writeFileSync(OUT_FILE, code)
 
-console.log('✅ OpenAPI types generated')
+const pathCount = Object.keys(schema.paths || {}).length
+const schemaCount = Object.keys(schema.components?.schemas || {}).length
+console.log(`Generated ${OUT_FILE}: ${pathCount} paths, ${schemaCount} schemas`)

--- a/scripts/sync-openapi.mjs
+++ b/scripts/sync-openapi.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const REPO_ROOT = process.cwd()
+const OUT_FILE = path.resolve(REPO_ROOT, 'specs/openapi-baseline.json')
+const DEFAULT_URL = 'https://api.amigo.ai/v1/openapi.json'
+const args = process.argv.slice(2)
+
+function getArgValue(name) {
+  const index = args.indexOf(name)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+async function loadSpec() {
+  const specArg = getArgValue('--spec')
+  if (specArg) {
+    const specPath = path.resolve(REPO_ROOT, specArg)
+    console.log(`Syncing OpenAPI snapshot from file: ${specPath}`)
+    const raw = fs.readFileSync(specPath, 'utf-8')
+    return JSON.parse(raw)
+  }
+
+  const specUrl = getArgValue('--url') ?? DEFAULT_URL
+  console.log(`Syncing OpenAPI snapshot from URL: ${specUrl}`)
+
+  const response = await fetch(specUrl)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch OpenAPI schema: HTTP ${response.status} ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+const document = await loadSpec()
+
+if (!document || typeof document !== 'object' || typeof document.openapi !== 'string') {
+  throw new Error('Invalid OpenAPI document received while syncing snapshot.')
+}
+
+fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true })
+fs.writeFileSync(OUT_FILE, `${JSON.stringify(document, null, 2)}\n`)
+
+console.log(`Wrote ${OUT_FILE}`)


### PR DESCRIPTION
## Summary
- add a visual front door with classic positioning and migration messaging
- switch codegen to the committed OpenAPI snapshot and add an explicit sync command
- align package metadata with the current release and add the rollup optional dependency workaround

## Verification
- npm run build
- npm test -- --reporter=dot
- npm run test:dist -- --reporter=dot

Note: the local Node 25/npm 11 environment required manual hydration of Rollup's darwin arm64 native package to work around npm's optional-dependency install bug.