### PR TITLE
Align package version with rc.2 tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amigo-ai/sdk",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amigo-ai/sdk",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amigo-ai/sdk",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Official TypeScript SDK for the classic Amigo API",
   "keywords": [
     "amigo",


### PR DESCRIPTION
## Summary
- align package.json and package-lock.json with the existing `v1.0.0-rc.2` tag
- unblock the next prerelease publish so it can advance to `rc.3` cleanly

## Verification
- npm version prerelease --preid rc --no-git-tag-version
- git diff --check