### PR TITLE
fix: align organization fixture with generated types

### DIFF
--- a/tests/resources/organization.test.ts
+++ b/tests/resources/organization.test.ts
@@ -13,11 +13,8 @@ const mockOrganizationResponse: components['schemas']['organization__get_organiz
   {
     org_id: 'test-org',
     org_name: 'Test Organization',
-    title: 'Welcome to Test Org',
-    main_description: 'This is a test organization for API testing',
-    sub_description: 'Built with Amigo AI platform',
-    onboarding_instructions: ['Step 1: Welcome', 'Step 2: Setup'],
     default_user_preferences: null,
+    tenant_id: null,
   }
 
 // MSW server setup


### PR DESCRIPTION
## Summary
- remove stale fields from the organization fixture used in docs/typecheck contexts
- keep the fixture aligned with the generated  schema

## Validation
- 
- 
[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages
