### PR TITLE
chore: remove transitive action runtime warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm ci
       - run: npm run gen-types
       - run: npm run docs
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !inputs.skip_codecov }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary
- move GitHub Pages artifact upload to  v5 to avoid the older upload-artifact path
- move Codecov to the pinned v6 action so coverage uploads stop pulling the older github-script runtime

## Validation
- parse updated workflow YAML with Ruby Psych
- run 
